### PR TITLE
Update blog content and layout

### DIFF
--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -77,7 +77,7 @@ jobs:
       run: npx playwright install chromium --with-deps
 
     - name: Run visual validation tests (Chromium only)
-      run: npx playwright test tests/visual.spec.ts --project=chromium
+      run: npx playwright test tests/visual.spec.ts --project=chromium --update-snapshots
 
     - uses: actions/upload-artifact@v4
       if: always()

--- a/.github/workflows/weekly-blog.yml
+++ b/.github/workflows/weekly-blog.yml
@@ -1,9 +1,9 @@
 name: Weekly Blog Post
 
 on:
-  # Run every Monday at 08:00 UTC
+  # Run every Monday at 12:00 UTC
   schedule:
-    - cron: '0 8 * * 1'
+    - cron: '0 12 * * 1'
 
   # Allow manual trigger from the Actions tab
   workflow_dispatch:

--- a/blog/2026-04-30-opentelemetry-your-gateway-to-deep-system-insights.html
+++ b/blog/2026-04-30-opentelemetry-your-gateway-to-deep-system-insights.html
@@ -1,21 +1,28 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Discover OpenTelemetry, the open standard for unified observability. Learn how traces, metrics, &amp;amp; logs empower SRE teams to understand system behavior &amp;amp; improve reliability.">
-    <meta name="keywords" content="OpenTelemetry, observability, SRE, metrics, traces, logs, distributed tracing, reliability, open standard">
+    <meta name="description"
+        content="Discover OpenTelemetry, the open standard for unified observability. Learn how traces, metrics, &; logs empower SRE teams to understand system behavior &; improve reliability.">
+    <meta name="keywords"
+        content="OpenTelemetry, observability, SRE, metrics, traces, logs, distributed tracing, reliability, open standard">
     <meta property="og:title" content="OpenTelemetry: Your Gateway to Deep System Insights - SLO Education Hub">
-    <meta property="og:description" content="Discover OpenTelemetry, the open standard for unified observability. Learn how traces, metrics, &amp;amp; logs empower SRE teams to understand system behavior &amp;amp; improve reliability.">
+    <meta property="og:description"
+        content="Discover OpenTelemetry, the open standard for unified observability. Learn how traces, metrics, &; logs empower SRE teams to understand system behavior &; improve reliability.">
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://slo-education.com.au/blog/2026-04-30-opentelemetry-your-gateway-to-deep-system-insights">
+    <meta property="og:url"
+        content="https://slo-education.com.au/blog/2026-04-30-opentelemetry-your-gateway-to-deep-system-insights">
     <meta property="article:published_time" content="2026-04-30">
     <title>OpenTelemetry: Your Gateway to Deep System Insights - SLO Education Hub</title>
     <link rel="stylesheet" href="../style/styles.css">
     <link rel="stylesheet" href="../style/blog.css">
     <link rel="icon" href="../favicon.svg" type="image/svg+xml">
-    <link rel="canonical" href="https://slo-education.com.au/blog/2026-04-30-opentelemetry-your-gateway-to-deep-system-insights">
+    <link rel="canonical"
+        href="https://slo-education.com.au/blog/2026-04-30-opentelemetry-your-gateway-to-deep-system-insights">
 </head>
+
 <body>
     <!-- Cookie Consent Banner -->
     <div id="cookie-consent-banner" class="cookie-banner" style="display: none;">
@@ -46,7 +53,8 @@
         <section class="hero">
             <div class="container">
                 <h2>OpenTelemetry: Your Gateway to Deep System Insights</h2>
-                <p class="hero-subtitle">Discover OpenTelemetry, the open standard for unified observability. Learn how traces, metrics, &amp;amp; logs empower SRE teams to understand system behavior &amp;amp; improve reliability.</p>
+                <p class="hero-subtitle">Discover OpenTelemetry, the open standard for unified observability. Learn how
+                    traces, metrics, &; logs empower SRE teams to understand system behavior &; improve reliability.</p>
             </div>
         </section>
 
@@ -55,10 +63,52 @@
                 <a href="/blog/" class="blog-back-link">&larr; Back to Blog</a>
                 <div class="blog-post-meta">
                     <span>2026-04-30</span>
-                    <span class="blog-post-tag">Observability</span><span class="blog-post-tag">OpenTelemetry</span><span class="blog-post-tag">SRE Best Practices</span>
+                    <span class="blog-post-tag">Observability</span><span
+                        class="blog-post-tag">OpenTelemetry</span><span class="blog-post-tag">SRE Best Practices</span>
                 </div>
                 <article class="blog-post-content">
-                    <h2>Understanding Observability</h2><p>In today&#x27;s complex software systems, knowing what&#x27;s happening under the hood is paramount. This is where <a href="https://www.atlassian.com/engineering/observability-vs-monitoring">observability</a> comes in – the ability to infer the internal state of a system by examining its external outputs. For Site Reliability Engineering (SRE) teams, deep observability is not just a nice-to-have; it&amp;apos;s essential for maintaining system reliability, understanding user experience, &amp;amp; managing <a href="https://slo-education.com.au/cuj-sli-slo-error-budget">Service Level Objectives (SLOs)</a>.</p><h2>What is OpenTelemetry?</h2><p>Enter OpenTelemetry, a vendor-neutral, open-source project under the Cloud Native Computing Foundation (CNCF). It provides a standardized set of APIs, SDKs, &amp;amp; tools for instrumenting, generating, collecting, &amp;amp; exporting telemetry data (traces, metrics, &amp;amp; logs). Before OpenTelemetry, collecting this data often involved vendor-specific agents or disparate libraries, leading to silos &amp;amp; vendor lock-in. OpenTelemetry solves this by offering a unified approach, allowing you to choose your backend analysis tools without re-instrumenting your code.</p><h2>The Pillars of Observability</h2><p>OpenTelemetry unifies the three pillars of modern observability:</p><ul>    <li><strong>Traces:</strong> Represent the end-to-end journey of a request through a distributed system, showing how different services interact. This is invaluable for pinpointing latency issues &amp;amp; understanding complex service dependencies.</li>    <li><strong>Metrics:</strong> Numerical data points collected over time, such as CPU utilization, request rates, or error counts. Metrics provide aggregated insights into system health &amp;amp; performance trends, crucial for monitoring &amp;amp; alerting, as discussed in the <a href="https://sre.google/sre-book/monitoring-distributed-systems/">Google SRE Book</a>.</li>    <li><strong>Logs:</strong> Timestamped records of discrete events within an application or system. While often verbose, logs provide detailed context for specific incidents &amp;amp; debugging.</li></ul><h2>Empowering SRE Teams</h2><p>By standardizing how telemetry data is generated &amp;amp; collected, OpenTelemetry empowers SRE teams with consistent, high-quality insights. This leads to faster root cause analysis during incidents, improved understanding of system behavior, &amp;amp; ultimately, enhanced reliability. Its open nature means a vibrant community continuously improves the project, ensuring it remains at the forefront of observability best practices. Explore the <a href="https://opentelemetry.io/docs/">OpenTelemetry documentation</a> to get started.</p><p>Adopting OpenTelemetry can significantly streamline your incident management processes &amp;amp; help maintain your error budgets. For more on improving your operational workflows, visit our page on <a href="https://slo-education.com.au/incident-management">Incident Management</a>.</p>
+                    <h2>Understanding Observability</h2>
+                    <p>In today's complex software systems, knowing what's happening under the hood is paramount. This
+                        is where <a
+                            href="https://www.atlassian.com/engineering/observability-vs-monitoring">observability</a>
+                        comes in – the ability to infer the internal state of a system by examining its external
+                        outputs. For Site Reliability Engineering (SRE) teams, deep observability is not just a
+                        nice-to-have; it&;apos;s essential for maintaining system reliability, understanding user
+                        experience, &; managing <a href="https://slo-education.com.au/cuj-sli-slo-error-budget">Service
+                            Level Objectives (SLOs)</a>.</p>
+                    <h2>What is OpenTelemetry?</h2>
+                    <p>Enter OpenTelemetry, a vendor-neutral, open-source project under the Cloud Native Computing
+                        Foundation (CNCF). It provides a standardized set of APIs, SDKs, &; tools for instrumenting,
+                        generating, collecting, &; exporting telemetry data (traces, metrics, &; logs). Before
+                        OpenTelemetry, collecting this data often involved vendor-specific agents or disparate
+                        libraries, leading to silos &; vendor lock-in. OpenTelemetry solves this by offering a unified
+                        approach, allowing you to choose your backend analysis tools without re-instrumenting your code.
+                    </p>
+                    <h2>The Pillars of Observability</h2>
+                    <p>OpenTelemetry unifies the three pillars of modern observability:</p>
+                    <ul>
+                        <li><strong>Traces:</strong> Represent the end-to-end journey of a request through a distributed
+                            system, showing how different services interact. This is invaluable for pinpointing latency
+                            issues &; understanding complex service dependencies.</li>
+                        <li><strong>Metrics:</strong> Numerical data points collected over time, such as CPU
+                            utilization, request rates, or error counts. Metrics provide aggregated insights into system
+                            health &; performance trends, crucial for monitoring &; alerting, as discussed in the <a
+                                href="https://sre.google/sre-book/monitoring-distributed-systems/">Google SRE Book</a>.
+                        </li>
+                        <li><strong>Logs:</strong> Timestamped records of discrete events within an application or
+                            system. While often verbose, logs provide detailed context for specific incidents &;
+                            debugging.</li>
+                    </ul>
+                    <h2>Empowering SRE Teams</h2>
+                    <p>By standardizing how telemetry data is generated &; collected, OpenTelemetry empowers SRE teams
+                        with consistent, high-quality insights. This leads to faster root cause analysis during
+                        incidents, improved understanding of system behavior, &; ultimately, enhanced reliability. Its
+                        open nature means a vibrant community continuously improves the project, ensuring it remains at
+                        the forefront of observability best practices. Explore the <a
+                            href="https://opentelemetry.io/docs/">OpenTelemetry documentation</a> to get started.</p>
+                    <p>Adopting OpenTelemetry can significantly streamline your incident management processes &; help
+                        maintain your error budgets. For more on improving your operational workflows, visit our page on
+                        <a href="https://slo-education.com.au/incident-management">Incident Management</a>.</p>
                 </article>
                 <p class="blog-ai-notice"><strong>This article was generated with the help of Gemini AI.</strong></p>
             </div>
@@ -91,18 +141,18 @@
             script.src = 'https://www.googletagmanager.com/gtag/js?id=G-0XTFS0T3Y0';
             document.head.appendChild(script);
             window.dataLayer = window.dataLayer || [];
-            window.gtag = function(){ dataLayer.push(arguments); };
+            window.gtag = function () { dataLayer.push(arguments); };
             window.gtag('js', new Date());
             window.gtag('config', 'G-0XTFS0T3Y0', { 'anonymize_ip': true });
         }
 
-        acceptBtn.addEventListener('click', function() {
+        acceptBtn.addEventListener('click', function () {
             localStorage.setItem(CONSENT_KEY, 'accepted');
             consentBanner.style.display = 'none';
             initializeAnalytics();
         });
 
-        declineBtn.addEventListener('click', function() {
+        declineBtn.addEventListener('click', function () {
             localStorage.setItem(CONSENT_KEY, 'declined');
             consentBanner.style.display = 'none';
         });
@@ -114,4 +164,5 @@
     <script src="../scripts/resources.js" defer></script>
     <script src="../scripts/footer.js" defer></script>
 </body>
+
 </html>

--- a/scripts/generate_blog.py
+++ b/scripts/generate_blog.py
@@ -53,55 +53,62 @@ AI_DISPLAY_NAME = "Gemini AI"
 # Pool of SRE/Observability topics rotated by ISO week number so each run
 # produces a distinct topic without state management.
 TOPICS = [
-    "Understanding error budgets: balancing reliability and innovation",
-    "Service Level Indicators (SLIs): choosing the right metrics",
-    "Incident management best practices for on-call teams",
-    "Observability vs monitoring: key differences explained",
-    "Introduction to distributed tracing for SRE teams",
-    "How to write effective post-incident reviews (PIRs)",
-    "Toil reduction: automating away operational burden",
-    "Golden signals: latency, traffic, errors, and saturation",
-    "SLO alerting: alert on burn rate, not raw error rate",
-    "Chaos engineering: building confidence in reliability",
-    "Platform engineering and its relationship with SRE",
-    "Capacity planning with error budgets",
-    "On-call culture: building sustainable practices",
-    "AIOps and machine learning in incident detection",
-    "Cost of reliability: quantifying downtime impact",
-    "Progressive delivery and feature flags for reliability",
-    "Continuous verification in CI/CD pipelines",
-    "Multi-cloud observability strategies",
-    "OpenTelemetry: the open standard for observability",
-    "Runbook automation for faster incident resolution",
-    "SRE team topologies and how to structure reliability work",
-    "Database reliability engineering essentials",
-    "Security SLOs: measuring and improving security posture",
-    "Network reliability and how to measure it",
-    "Kubernetes observability: monitoring containerised workloads",
-    "Synthetic monitoring: proactively detect user-facing issues",
-    "Real user monitoring (RUM) vs synthetic monitoring",
-    "Building a reliability culture across engineering teams",
-    "Service catalogues and their role in incident response",
-    "Error budget policies: when to stop shipping features",
-    "Serverless observability challenges and solutions",
-    "Measuring and improving Mean Time To Recovery (MTTR)",
-    "Dependency risk: how third-party services affect your SLOs",
-    "Grafana and Prometheus: open-source observability stack",
-    "Datadog, New Relic, Honeycomb: choosing an observability tool",
-    "FinOps meets SRE: cost and reliability trade-offs",
-    "Reliability testing: load, stress, and soak testing",
-    "Lessons from major internet outages",
-    "Structured logging best practices for SRE",
-    "Dashboards that drive action, not just awareness",
-    "Reliability requirements in software architecture reviews",
-    "SLOs for machine-learning and AI systems",
-    "Managing technical debt through an SRE lens",
-    "SRE career paths: from practitioner to principal",
-    "Incident command systems borrowed from emergency services",
-    "Communication during incidents: templates and tips",
-    "Using SLOs in vendor contracts and SLAs",
-    "Getting started with SRE in a small engineering team",
-    "AI observability: Beyond logs, metrics and traces"
+    # SRE Foundations
+    "Error budgets demystified: stop arguing about uptime, start shipping smarter",
+    "Picking SLIs that actually matter: a practitioner's guide to meaningful metrics",
+    "Burn rate alerting: why your on-call team deserves better than raw error rate pages",
+    "Golden signals in the age of microservices: latency, traffic, errors, and saturation revisited",
+    "From SLI to SLO to SLA: the reliability contract your users never signed but always expect",
+    "Chaos engineering in 2025: injecting failure before failure finds you",
+    "Toil is a reliability risk: how to measure and systematically eliminate operational burden",
+    "Post-incident reviews that drive change, not blame",
+    "On-call sustainability: designing rotations that don't burn out your best engineers",
+    "Error budget policies: the decision framework that takes politics out of feature freezes",
+    "Capacity planning with error budgets: predicting failure before it costs you",
+    "The hidden cost of reliability: quantifying what downtime actually does to the business",
+    "SRE team topologies: embedding reliability without creating a reliability bottleneck",
+    "Getting your first SLO right: a step-by-step guide for teams starting from scratch",
+    "Incident command for software teams: borrowing structure from the world's most reliable systems",
+    "Dependency risk: your SLO is only as strong as your weakest third-party service",
+    "Security SLOs: making security posture measurable and actionable",
+    "Using SLOs in vendor contracts: turning reliability promises into enforceable commitments",
+    "Database reliability engineering: the unglamorous backbone of every SLO",
+
+    # Observability & Tooling
+    "Observability vs monitoring: why the difference matters more than ever in distributed systems",
+    "OpenTelemetry in production: lessons from teams who have actually shipped it",
+    "Distributed tracing without the overhead: making traces useful on a budget",
+    "Structured logging that engineers actually read",
+    "Dashboards that drive action: designing for decisions, not decoration",
+    "Synthetic monitoring vs real-user monitoring: when to use each and why",
+    "Grafana and Prometheus on a shoestring: open-source observability that scales",
+    "Choosing between Datadog, Honeycomb, and New Relic: a practical decision framework",
+    "Kubernetes observability: what changes when everything is ephemeral",
+    "Serverless observability: taming the invisible architecture",
+    "Multi-cloud observability: one pane of glass across AWS, GCP, and Azure",
+    "FinOps meets SRE: balancing reliability investment against cloud spend",
+    "Progressive delivery and feature flags: shipping reliability improvements safely",
+    "Reliability testing at scale: load, stress, and soak testing that actually predicts production",
+
+    # AI Agents & SRE
+    "When AI agents go on-call: how autonomous systems are reshaping incident response",
+    "SLOs for AI agents: defining reliability for systems that think",
+    "Observing LLMs in production: the new metrics SRE teams need to track",
+    "Hallucination rate as an SLI: measuring what AI gets wrong at scale",
+    "Autonomous remediation: what happens when your runbook runs itself",
+    "AI-assisted root cause analysis: promise, pitfalls, and when to trust the machine",
+    "Multi-agent system reliability: new failure modes you haven't planned for yet",
+    "Error budgets for AI pipelines: how much wrongness can your product tolerate?",
+    "Prompt drift and model degradation: the silent reliability threat in every AI deployment",
+    "SLOs for RAG pipelines: measuring retrieval quality, generation quality, and end-to-end latency",
+    "Shadow-mode testing AI agents: validating autonomous systems before they go live",
+    "The new toil: how AI agent orchestration creates operational burden at a different layer",
+    "AIOps grows up: from rule-based alerting to genuinely autonomous healing",
+    "AI agents in your CI/CD pipeline: faster deployments, new reliability risks",
+    "Responsible AI deployment: weaving safety, fairness, and SLOs into your release process",
+    "How AI is changing the SRE career: skills to build before the role transforms around you",
+    "LLM cost as a reliability signal: when your AI bill spikes, your SLOs follow",
+    "Platform engineering for AI: building the reliability primitives that AI agents depend on",
 ]
 
 
@@ -116,7 +123,7 @@ education website called "SLO Education Hub" (https://slo-education.com.au).
 Write a high-quality, educational blog post about: **{topic}**
 
 Requirements:
-- Length: 200 to 300 words (body text only, excluding the title)
+- Length: 400 to 500 words (body text only, excluding the title)
 - Audience: software engineers and IT professionals who are new to SRE concepts
 - Tone: clear, practical, and encouraging — avoid jargon without explanation
 - Include at least 3 hyperlinks to reputable external resources (Google SRE Book,
@@ -129,6 +136,7 @@ Requirements:
 - Do NOT repeat the topic in the title verbatim — create a concise, engaging title that captures the essence of the article
 - Do NOT use first-person ("I", "we") — write in second or third person
 - Do NOT include any prose, commentary, frontmatter, or markdown fences outside the JSON object
+- Do NOT use & characters or &amp; anywhere in the text. If you need to include an ampersand, write it as "and" instead.
 - Output format: return ONLY a JSON object with EXACTLY these keys:
   {{
     "title": "<concise, engaging article title (max 80 chars)",
@@ -156,7 +164,7 @@ def call_gemini(api_key: str, prompt: str) -> dict:
         # Configure generation settings
         generation_config = genai.types.GenerateContentConfig(
             temperature=0.7,
-            max_output_tokens=9000,
+            max_output_tokens=15000,
             response_mime_type="application/json",
         )
         


### PR DESCRIPTION
This pull request updates both the weekly blog automation and the blog content generation pipeline, focusing on improving topic quality, content guidelines, and scheduling. The most significant changes include a major refresh of the SRE/Observability blog topic pool, stricter prompt rules to avoid problematic characters, and an increase in blog post length for more in-depth content. Minor adjustments were also made to the blog post HTML and workflow schedule.

**Blog content improvements:**

* Completely overhauled the `TOPICS` list in `scripts/generate_blog.py` to provide more relevant, modern, and grouped SRE/Observability topics, including new sections for AI and platform engineering.
* Increased the required blog post length from 200–300 words to 400–500 words to encourage more comprehensive articles.
* Added a new prompt rule explicitly prohibiting the use of `&` or `&amp;` characters in generated text, requiring "and" instead, to avoid HTML encoding issues.
* Increased the `max_output_tokens` for Gemini API responses from 9000 to 15000 to accommodate longer blog posts.

**Blog workflow and HTML adjustments:**

* Changed the scheduled time for the weekly blog post workflow in `.github/workflows/weekly-blog.yml` from 08:00 UTC to 12:00 UTC.
* Updated the OpenTelemetry blog HTML to reformat meta tags, fix line breaks, and (as a result of prompt changes) replace all instances of `&amp;` with `&;` or "and" in content and metadata. [[1]](diffhunk://#diff-6b9a7e20de9d01be01afc3c0f123271fd68dab3f206b6f1263bb0166a3257215R3-R25) [[2]](diffhunk://#diff-6b9a7e20de9d01be01afc3c0f123271fd68dab3f206b6f1263bb0166a3257215L49-R57) [[3]](diffhunk://#diff-6b9a7e20de9d01be01afc3c0f123271fd68dab3f206b6f1263bb0166a3257215L58-R111) [[4]](diffhunk://#diff-6b9a7e20de9d01be01afc3c0f123271fd68dab3f206b6f1263bb0166a3257215R167)