### PR TITLE
Fix HTML character entities in blog links

### DIFF
--- a/blog/2026-03-10-empowering-reliability-the-platform-engineering-sre-synergy.html
+++ b/blog/2026-03-10-empowering-reliability-the-platform-engineering-sre-synergy.html
@@ -62,7 +62,7 @@
 
         <section class="section">
             <div class="container">
-                <a href="/blog/" class="blog-back-link">&larr; Back to Blog</a>
+                <a href="/blog/" class="blog-back-link">← Back to Blog</a>
                 <div class="blog-post-meta">
                     <span>2026-03-10</span>
                     <span class="blog-post-tag">Platform Engineering</span><span class="blog-post-tag">SRE

--- a/blog/2026-03-16-unlocking-observability-in-microservices-with-service-meshes.html
+++ b/blog/2026-03-16-unlocking-observability-in-microservices-with-service-meshes.html
@@ -61,7 +61,7 @@
 
         <section class="section">
             <div class="container">
-                <a href="/blog/" class="blog-back-link">&larr; Back to Blog</a>
+                <a href="/blog/" class="blog-back-link">← Back to Blog</a>
                 <div class="blog-post-meta">
                     <span>2026-03-16</span>
                     <span class="blog-post-tag">SRE</span><span class="blog-post-tag">Observability</span><span

--- a/blog/2026-03-23-ai-amp-ml-for-smarter-incident-detection.html
+++ b/blog/2026-03-23-ai-amp-ml-for-smarter-incident-detection.html
@@ -59,7 +59,7 @@
 
         <section class="section">
             <div class="container">
-                <a href="/blog/" class="blog-back-link">&larr; Back to Blog</a>
+                <a href="/blog/" class="blog-back-link">← Back to Blog</a>
                 <div class="blog-post-meta">
                     <span>2026-03-23</span>
                     <span class="blog-post-tag">AIOps</span><span class="blog-post-tag">Machine Learning</span><span

--- a/blog/2026-03-30-the-true-cost-of-downtime-quantifying-unreliability.html
+++ b/blog/2026-03-30-the-true-cost-of-downtime-quantifying-unreliability.html
@@ -61,7 +61,7 @@
 
         <section class="section">
             <div class="container">
-                <a href="/blog/" class="blog-back-link">&larr; Back to Blog</a>
+                <a href="/blog/" class="blog-back-link">← Back to Blog</a>
                 <div class="blog-post-meta">
                     <span>2026-03-30</span>
                     <span class="blog-post-tag">SRE</span><span class="blog-post-tag">Reliability</span><span

--- a/blog/2026-04-06-deploy-with-confidence-progressive-delivery-amp-feature-flags.html
+++ b/blog/2026-04-06-deploy-with-confidence-progressive-delivery-amp-feature-flags.html
@@ -61,7 +61,7 @@
 
         <section class="section">
             <div class="container">
-                <a href="/blog/" class="blog-back-link">&larr; Back to Blog</a>
+                <a href="/blog/" class="blog-back-link">← Back to Blog</a>
                 <div class="blog-post-meta">
                     <span>2026-04-06</span>
                     <span class="blog-post-tag">Deployment</span><span class="blog-post-tag">Reliability</span><span

--- a/blog/2026-04-30-bolstering-slos-the-essential-role-of-database-reliability.html
+++ b/blog/2026-04-30-bolstering-slos-the-essential-role-of-database-reliability.html
@@ -61,7 +61,7 @@
 
         <section class="section">
             <div class="container">
-                <a href="/blog/" class="blog-back-link">&larr; Back to Blog</a>
+                <a href="/blog/" class="blog-back-link">← Back to Blog</a>
                 <div class="blog-post-meta">
                     <span>2026-04-30</span>
                     <span class="blog-post-tag">SRE</span><span class="blog-post-tag">Databases</span><span

--- a/blog/2026-04-30-opentelemetry-your-gateway-to-deep-system-insights.html
+++ b/blog/2026-04-30-opentelemetry-your-gateway-to-deep-system-insights.html
@@ -60,7 +60,7 @@
 
         <section class="section">
             <div class="container">
-                <a href="/blog/" class="blog-back-link">&larr; Back to Blog</a>
+                <a href="/blog/" class="blog-back-link">← Back to Blog</a>
                 <div class="blog-post-meta">
                     <span>2026-04-30</span>
                     <span class="blog-post-tag">Observability</span><span

--- a/blog/2026-05-04-beyond-alerts-why-observability-is-key-for-modern-systems.html
+++ b/blog/2026-05-04-beyond-alerts-why-observability-is-key-for-modern-systems.html
@@ -1,21 +1,28 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Understand the critical differences between observability and monitoring in distributed systems. Learn why observability is essential for SRE and effective incident response.">
-    <meta name="keywords" content="observability, monitoring, SRE, distributed systems, incident management, site reliability engineering, metrics, logs, traces">
+    <meta name="description"
+        content="Understand the critical differences between observability and monitoring in distributed systems. Learn why observability is essential for SRE and effective incident response.">
+    <meta name="keywords"
+        content="observability, monitoring, SRE, distributed systems, incident management, site reliability engineering, metrics, logs, traces">
     <meta property="og:title" content="Beyond Alerts: Why Observability is Key for Modern Systems - SLO Education Hub">
-    <meta property="og:description" content="Understand the critical differences between observability and monitoring in distributed systems. Learn why observability is essential for SRE and effective incident response.">
+    <meta property="og:description"
+        content="Understand the critical differences between observability and monitoring in distributed systems. Learn why observability is essential for SRE and effective incident response.">
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://slo-education.com.au/blog/2026-05-04-beyond-alerts-why-observability-is-key-for-modern-systems">
+    <meta property="og:url"
+        content="https://slo-education.com.au/blog/2026-05-04-beyond-alerts-why-observability-is-key-for-modern-systems">
     <meta property="article:published_time" content="2026-05-04">
     <title>Beyond Alerts: Why Observability is Key for Modern Systems - SLO Education Hub</title>
     <link rel="stylesheet" href="../style/styles.css">
     <link rel="stylesheet" href="../style/blog.css">
     <link rel="icon" href="../favicon.svg" type="image/svg+xml">
-    <link rel="canonical" href="https://slo-education.com.au/blog/2026-05-04-beyond-alerts-why-observability-is-key-for-modern-systems">
+    <link rel="canonical"
+        href="https://slo-education.com.au/blog/2026-05-04-beyond-alerts-why-observability-is-key-for-modern-systems">
 </head>
+
 <body>
     <!-- Cookie Consent Banner -->
     <div id="cookie-consent-banner" class="cookie-banner" style="display: none;">
@@ -46,19 +53,82 @@
         <section class="hero">
             <div class="container">
                 <h2>Beyond Alerts: Why Observability is Key for Modern Systems</h2>
-                <p class="hero-subtitle">Understand the critical differences between observability and monitoring in distributed systems. Learn why observability is essential for SRE and effective incident response.</p>
+                <p class="hero-subtitle">Understand the critical differences between observability and monitoring in
+                    distributed systems. Learn why observability is essential for SRE and effective incident response.
+                </p>
             </div>
         </section>
 
         <section class="section">
             <div class="container">
-                <a href="/blog/" class="blog-back-link">&larr; Back to Blog</a>
+                <a href="/blog/" class="blog-back-link">← Back to Blog</a>
                 <div class="blog-post-meta">
                     <span>2026-05-04</span>
-                    <span class="blog-post-tag">SRE</span><span class="blog-post-tag">Observability</span><span class="blog-post-tag">Monitoring</span>
+                    <span class="blog-post-tag">SRE</span><span class="blog-post-tag">Observability</span><span
+                        class="blog-post-tag">Monitoring</span>
                 </div>
                 <article class="blog-post-content">
-                    <h2>Monitoring vs. Observability: A Crucial Distinction for SRE</h2><p>Modern software systems are complex, distributed beasts. Understanding their health and behavior is paramount for reliability. While monitoring has been a cornerstone for years, a new paradigm, observability, is gaining crucial importance, especially for those venturing into Site Reliability Engineering (SRE).</p><h3>What is Monitoring?</h3><p>At its core, monitoring involves collecting pre-defined metrics and logs to track the health and performance of your systems. It&#x27;s about knowing the &quot;known unknowns.&quot; You define what to look for &amp;mdash; CPU utilization, memory usage, request rates, error counts &amp;mdash; and set alerts when these predefined thresholds are breached. Monitoring tells you <em>if</em> something is wrong and often <em>what</em> is wrong, based on what you expected to go wrong. It&#x27;s excellent for understanding the performance of individual components or well-understood failure modes.</p><h3>What is Observability?</h3><p>Observability, on the other hand, is the ability to infer the internal state of a system by examining its external outputs. It&#x27;s about exploring the &quot;unknown unknowns.&quot; Instead of just predefined metrics, an observable system provides rich data &amp;mdash; metrics, logs, and traces &amp;mdash; that allow engineers to ask <em>arbitrary questions</em> about its behavior without deploying new code.</p><ul><li><strong>Metrics:</strong> Numerical data points collected over time (e.g., request latency, error rates).</li><li><strong>Logs:</strong> Timestamped records of discrete events (e.g., an error message, a user login, a function call).</li><li><strong>Traces:</strong> End-to-end views of requests as they flow through multiple services, showing dependencies and latency at each step. Projects like <a href="https://opentelemetry.io/docs/">OpenTelemetry</a> are key to enabling this.</li></ul><h3>Why the Difference Matters in Distributed Systems</h3><p>In a monolithic application, monitoring a few key metrics might suffice. But in distributed systems, with microservices, containers, and serverless functions, the interactions are incredibly complex. A single user request might touch dozens of services.</p><p>When an issue arises, traditional monitoring might tell you <em>which service</em> is failing, but not <em>why</em> it&#x27;s failing or <em>how</em> that failure propagates across the entire system. This is where observability shines. By correlating metrics, logs, and traces, engineers can piece together the entire journey of a request, pinpointing the exact service, function, or even line of code responsible for an issue, even if it&#x27;s a completely novel failure mode. This deep insight is critical for effective <a href="https://slo-education.com.au/incident-management">incident management</a> and reducing Mean Time To Resolution (MTTR).</p><h3>Observability and SRE</h3><p>SRE practices heavily rely on observability to define and achieve Service Level Objectives (SLOs). You cannot reliably measure your <a href="https://slo-education.com.au/cuj-sli-slo-error-budget">Customer Journey (CUJ) &amp;rarr; Service Level Indicators (SLI) &amp;rarr; Service Level Objectives (SLO)</a> without the rich data provided by an observable system. The <a href="https://sre.google/sre-book/monitoring-distributed-systems/">Google SRE Book</a> emphasizes the importance of understanding system behavior to manage reliability, highlighting the need for comprehensive data. The <a href="https://www.cncf.io/blog/2022/02/09/observability-vs-monitoring-what-is-the-difference/">Cloud Native Computing Foundation (CNCF)</a> also provides valuable insights into this distinction.</p><p>Observability empowers SRE teams to proactively identify degradation, debug complex issues, and make informed decisions about system health and error budget allocation.</p><h3>Conclusion</h3><p>Monitoring tells you <em>what</em> is happening based on what you expect. Observability allows you to understand <em>why</em> it&#x27;s happening, even for unforeseen issues. For anyone involved in building or operating modern, distributed software, embracing observability is not just a best practice; it&#x27;s a fundamental shift towards building more resilient, understandable, and ultimately, more reliable systems. Start exploring how you can instrument your applications to gain this unparalleled insight today.</p>
+                    <h2>Monitoring vs. Observability: A Crucial Distinction for SRE</h2>
+                    <p>Modern software systems are complex, distributed beasts. Understanding their health and behavior
+                        is paramount for reliability. While monitoring has been a cornerstone for years, a new paradigm,
+                        observability, is gaining crucial importance, especially for those venturing into Site
+                        Reliability Engineering (SRE).</p>
+                    <h3>What is Monitoring?</h3>
+                    <p>At its core, monitoring involves collecting pre-defined metrics and logs to track the health and
+                        performance of your systems. It's about knowing the "known unknowns." You define
+                        what to look for — CPU utilization, memory usage, request rates, error counts
+                        — and set alerts when these predefined thresholds are breached. Monitoring tells you
+                        <em>if</em> something is wrong and often <em>what</em> is wrong, based on what you expected to
+                        go wrong. It's excellent for understanding the performance of individual components or
+                        well-understood failure modes.</p>
+                    <h3>What is Observability?</h3>
+                    <p>Observability, on the other hand, is the ability to infer the internal state of a system by
+                        examining its external outputs. It's about exploring the "unknown unknowns."
+                        Instead of just predefined metrics, an observable system provides rich data — metrics,
+                        logs, and traces — that allow engineers to ask <em>arbitrary questions</em> about its
+                        behavior without deploying new code.</p>
+                    <ul>
+                        <li><strong>Metrics:</strong> Numerical data points collected over time (e.g., request latency,
+                            error rates).</li>
+                        <li><strong>Logs:</strong> Timestamped records of discrete events (e.g., an error message, a
+                            user login, a function call).</li>
+                        <li><strong>Traces:</strong> End-to-end views of requests as they flow through multiple
+                            services, showing dependencies and latency at each step. Projects like <a
+                                href="https://opentelemetry.io/docs/">OpenTelemetry</a> are key to enabling this.</li>
+                    </ul>
+                    <h3>Why the Difference Matters in Distributed Systems</h3>
+                    <p>In a monolithic application, monitoring a few key metrics might suffice. But in distributed
+                        systems, with microservices, containers, and serverless functions, the interactions are
+                        incredibly complex. A single user request might touch dozens of services.</p>
+                    <p>When an issue arises, traditional monitoring might tell you <em>which service</em> is failing,
+                        but not <em>why</em> it's failing or <em>how</em> that failure propagates across the entire
+                        system. This is where observability shines. By correlating metrics, logs, and traces, engineers
+                        can piece together the entire journey of a request, pinpointing the exact service, function, or
+                        even line of code responsible for an issue, even if it's a completely novel failure mode.
+                        This deep insight is critical for effective <a
+                            href="https://slo-education.com.au/incident-management">incident management</a> and reducing
+                        Mean Time To Resolution (MTTR).</p>
+                    <h3>Observability and SRE</h3>
+                    <p>SRE practices heavily rely on observability to define and achieve Service Level Objectives
+                        (SLOs). You cannot reliably measure your <a
+                            href="https://slo-education.com.au/cuj-sli-slo-error-budget">Customer Journey (CUJ)
+                            → Service Level Indicators (SLI) → Service Level Objectives (SLO)</a>
+                        without the rich data provided by an observable system. The <a
+                            href="https://sre.google/sre-book/monitoring-distributed-systems/">Google SRE Book</a>
+                        emphasizes the importance of understanding system behavior to manage reliability, highlighting
+                        the need for comprehensive data. The <a
+                            href="https://www.cncf.io/blog/2022/02/09/observability-vs-monitoring-what-is-the-difference/">Cloud
+                            Native Computing Foundation (CNCF)</a> also provides valuable insights into this
+                        distinction.</p>
+                    <p>Observability empowers SRE teams to proactively identify degradation, debug complex issues, and
+                        make informed decisions about system health and error budget allocation.</p>
+                    <h3>Conclusion</h3>
+                    <p>Monitoring tells you <em>what</em> is happening based on what you expect. Observability allows
+                        you to understand <em>why</em> it's happening, even for unforeseen issues. For anyone
+                        involved in building or operating modern, distributed software, embracing observability is not
+                        just a best practice; it's a fundamental shift towards building more resilient,
+                        understandable, and ultimately, more reliable systems. Start exploring how you can instrument
+                        your applications to gain this unparalleled insight today.</p>
                 </article>
                 <p class="blog-ai-notice"><strong>This article was generated with the help of Gemini AI.</strong></p>
             </div>
@@ -91,18 +161,18 @@
             script.src = 'https://www.googletagmanager.com/gtag/js?id=G-0XTFS0T3Y0';
             document.head.appendChild(script);
             window.dataLayer = window.dataLayer || [];
-            window.gtag = function(){ dataLayer.push(arguments); };
+            window.gtag = function () { dataLayer.push(arguments); };
             window.gtag('js', new Date());
             window.gtag('config', 'G-0XTFS0T3Y0', { 'anonymize_ip': true });
         }
 
-        acceptBtn.addEventListener('click', function() {
+        acceptBtn.addEventListener('click', function () {
             localStorage.setItem(CONSENT_KEY, 'accepted');
             consentBanner.style.display = 'none';
             initializeAnalytics();
         });
 
-        declineBtn.addEventListener('click', function() {
+        declineBtn.addEventListener('click', function () {
             localStorage.setItem(CONSENT_KEY, 'declined');
             consentBanner.style.display = 'none';
         });
@@ -114,4 +184,5 @@
     <script src="../scripts/resources.js" defer></script>
     <script src="../scripts/footer.js" defer></script>
 </body>
+
 </html>

--- a/blog/index.html
+++ b/blog/index.html
@@ -52,49 +52,49 @@
   <div class="blog-card-meta"><span>2026-05-04</span><span class="blog-card-tag">SRE</span><span class="blog-card-tag">Observability</span><span class="blog-card-tag">Monitoring</span></div>
   <h3><a href="/blog/2026-05-04-beyond-alerts-why-observability-is-key-for-modern-systems">Beyond Alerts: Why Observability is Key for Modern Systems</a></h3>
   <p>Understand the critical differences between observability and monitoring in distributed systems. Learn why observability is essential for SRE and effective incident response.</p>
-  <a href="/blog/2026-05-04-beyond-alerts-why-observability-is-key-for-modern-systems" class="read-more">Read more &rarr;</a>
+  <a href="/blog/2026-05-04-beyond-alerts-why-observability-is-key-for-modern-systems" class="read-more">Read more →</a>
 </div>
                     <div class="blog-card">
   <div class="blog-card-meta"><span>2026-04-30</span><span class="blog-card-tag">SRE</span><span class="blog-card-tag">Databases</span><span class="blog-card-tag">SLOs</span></div>
   <h3><a href="/blog/2026-04-30-bolstering-slos-the-essential-role-of-database-reliability">Bolstering SLOs: The Essential Role of Database Reliability</a></h3>
   <p>Discover why database reliability engineering is crucial for achieving your Service Level Objectives (SLOs). Learn practical strategies for resilient databases and how they underpin system stability.</p>
-  <a href="/blog/2026-04-30-bolstering-slos-the-essential-role-of-database-reliability" class="read-more">Read more &rarr;</a>
+  <a href="/blog/2026-04-30-bolstering-slos-the-essential-role-of-database-reliability" class="read-more">Read more →</a>
 </div>
                     <div class="blog-card">
   <div class="blog-card-meta"><span>2026-04-30</span><span class="blog-card-tag">Observability</span><span class="blog-card-tag">OpenTelemetry</span><span class="blog-card-tag">SRE Best Practices</span></div>
   <h3><a href="/blog/2026-04-30-opentelemetry-your-gateway-to-deep-system-insights">OpenTelemetry: Your Gateway to Deep System Insights</a></h3>
   <p>Discover OpenTelemetry, the open standard for unified observability. Learn how traces, metrics, &amp; logs empower SRE teams to understand system behavior &amp; improve reliability.</p>
-  <a href="/blog/2026-04-30-opentelemetry-your-gateway-to-deep-system-insights" class="read-more">Read more &rarr;</a>
+  <a href="/blog/2026-04-30-opentelemetry-your-gateway-to-deep-system-insights" class="read-more">Read more →</a>
 </div>
                     <div class="blog-card">
   <div class="blog-card-meta"><span>2026-04-06</span><span class="blog-card-tag">Deployment</span><span class="blog-card-tag">Reliability</span><span class="blog-card-tag">SRE Best Practices</span></div>
   <h3><a href="/blog/2026-04-06-deploy-with-confidence-progressive-delivery-amp-feature-flags">Deploy with Confidence: Progressive Delivery &amp; Feature Flags</a></h3>
   <p>Learn how progressive delivery and feature flags enhance software reliability, reduce deployment risks, and improve incident response for SRE beginners.</p>
-  <a href="/blog/2026-04-06-deploy-with-confidence-progressive-delivery-amp-feature-flags" class="read-more">Read more &rarr;</a>
+  <a href="/blog/2026-04-06-deploy-with-confidence-progressive-delivery-amp-feature-flags" class="read-more">Read more →</a>
 </div>
                     <div class="blog-card">
   <div class="blog-card-meta"><span>2026-03-30</span><span class="blog-card-tag">SRE</span><span class="blog-card-tag">Reliability</span><span class="blog-card-tag">Downtime</span></div>
   <h3><a href="/blog/2026-03-30-the-true-cost-of-downtime-quantifying-unreliability">The True Cost of Downtime: Quantifying Unreliability</a></h3>
   <p>Discover how to quantify the true cost of downtime for your services. Learn about direct &amp; indirect impacts, from lost revenue to reputational damage, crucial for SRE beginners.</p>
-  <a href="/blog/2026-03-30-the-true-cost-of-downtime-quantifying-unreliability" class="read-more">Read more &rarr;</a>
+  <a href="/blog/2026-03-30-the-true-cost-of-downtime-quantifying-unreliability" class="read-more">Read more →</a>
 </div>
                     <div class="blog-card">
   <div class="blog-card-meta"><span>2026-03-23</span><span class="blog-card-tag">AIOps</span><span class="blog-card-tag">Machine Learning</span><span class="blog-card-tag">Incident Management</span><span class="blog-card-tag">SRE Fundamentals</span><span class="blog-card-tag">Observability</span></div>
   <h3><a href="/blog/2026-03-23-ai-amp-ml-for-smarter-incident-detection">AI &amp; ML for Smarter Incident Detection</a></h3>
   <p>Discover how AIOps and machine learning revolutionize incident detection for SREs. Learn to reduce alert fatigue, identify anomalies faster, and improve system reliability.</p>
-  <a href="/blog/2026-03-23-ai-amp-ml-for-smarter-incident-detection" class="read-more">Read more &rarr;</a>
+  <a href="/blog/2026-03-23-ai-amp-ml-for-smarter-incident-detection" class="read-more">Read more →</a>
 </div>
                     <div class="blog-card">
   <div class="blog-card-meta"><span>2026-03-16</span><span class="blog-card-tag">SRE</span><span class="blog-card-tag">Observability</span><span class="blog-card-tag">Service Mesh</span></div>
   <h3><a href="/blog/2026-03-16-unlocking-observability-in-microservices-with-service-meshes">Unlocking Observability in Microservices with Service Meshes</a></h3>
   <p>Explore how service meshes enhance observability in microservices. Learn practical insights for SRE beginners on gaining visibility into distributed systems.</p>
-  <a href="/blog/2026-03-16-unlocking-observability-in-microservices-with-service-meshes" class="read-more">Read more &rarr;</a>
+  <a href="/blog/2026-03-16-unlocking-observability-in-microservices-with-service-meshes" class="read-more">Read more →</a>
 </div>
                     <div class="blog-card">
   <div class="blog-card-meta"><span>2026-03-10</span><span class="blog-card-tag">Platform Engineering</span><span class="blog-card-tag">SRE Fundamentals</span><span class="blog-card-tag">DevOps</span></div>
 <h3><a href="/blog/2026-03-10-empowering-reliability-the-platform-engineering-sre-synergy">Empowering Reliability: The Platform Engineering &amp; SRE Synergy</a></h3>
   <p>Discover how platform engineering empowers SRE teams by providing robust tools and automation, enhancing reliability, and improving developer experience. Learn their synergistic relationship.</p>
-  <a href="/blog/2026-03-10-empowering-reliability-the-platform-engineering-sre-synergy" class="read-more">Read more &rarr;</a>
+  <a href="/blog/2026-03-10-empowering-reliability-the-platform-engineering-sre-synergy" class="read-more">Read more →</a>
 </div>
                     <!-- Blog posts are injected here by the weekly-blog workflow -->
                     

--- a/scripts/generate_blog.py
+++ b/scripts/generate_blog.py
@@ -137,6 +137,11 @@ Requirements:
 - Do NOT use first-person ("I", "we") — write in second or third person
 - Do NOT include any prose, commentary, frontmatter, or markdown fences outside the JSON object
 - Do NOT use & characters or &amp; anywhere in the text. If you need to include an ampersand, write it as "and" instead.
+- Do NOT use &#x27; or similar numeric character references for apostrophes — use a plain ' character instead.
+- Do NOT use &amp;rarr; or similar entities for arrows — use a plain → character instead.
+- Do NOT use &amp;mdash; or similar entities for em dashes — use a plain — character instead.
+- Do NOT use &quot; or similar entities for quotes — use plain " characters instead.
+- Do NOT use &larr; or &rarr; or similar entities for arrows — use plain ← and → characters instead.
 - Output format: return ONLY a JSON object with EXACTLY these keys:
   {{
     "title": "<concise, engaging article title (max 80 chars)",
@@ -363,7 +368,7 @@ def render_post_html(
 
         <section class="section">
             <div class="container">
-                <a href="/blog/" class="blog-back-link">&larr; Back to Blog</a>
+                <a href="/blog/" class="blog-back-link">← Back to Blog</a>
                 <div class="blog-post-meta">
                     <span>{pub_date}</span>
                     {tags_html}

--- a/scripts/generate_blog.py
+++ b/scripts/generate_blog.py
@@ -136,12 +136,10 @@ Requirements:
 - Do NOT repeat the topic in the title verbatim — create a concise, engaging title that captures the essence of the article
 - Do NOT use first-person ("I", "we") — write in second or third person
 - Do NOT include any prose, commentary, frontmatter, or markdown fences outside the JSON object
-- Do NOT use & characters or &amp; anywhere in the text. If you need to include an ampersand, write it as "and" instead.
-- Do NOT use &#x27; or similar numeric character references for apostrophes — use a plain ' character instead.
-- Do NOT use &amp;rarr; or similar entities for arrows — use a plain → character instead.
-- Do NOT use &amp;mdash; or similar entities for em dashes — use a plain — character instead.
-- Do NOT use &quot; or similar entities for quotes — use plain " characters instead.
-- Do NOT use &larr; or &rarr; or similar entities for arrows — use plain ← and → characters instead.
+- Do NOT use numeric character references (such as &#x27;) for apostrophes — use a plain ' character instead.
+- Do NOT use named HTML entities for arrows (rarr, larr) — use the plain Unicode characters → and ← instead.
+- Do NOT use named HTML entities for em dashes (mdash) — use a plain — character instead.
+- Do NOT use named HTML entities for quotes (quot) — use plain " characters instead.
 - Output format: return ONLY a JSON object with EXACTLY these keys:
   {{
     "title": "<concise, engaging article title (max 80 chars)",
@@ -446,7 +444,7 @@ def build_card_html(title: str, description: str, tags: list, pub_date: str, slu
         f'  <div class="blog-card-meta"><span>{pub_date}</span>{tags_html}</div>\n'
         f'  <h3><a href="/blog/{slug}">{title}</a></h3>\n'
         f'  <p>{description}</p>\n'
-        f'  <a href="/blog/{slug}" class="read-more">Read more &rarr;</a>\n'
+        f'  <a href="/blog/{slug}" class="read-more">Read more →</a>\n'
         f'</div>'
     )
 

--- a/tests/test_generate_blog.py
+++ b/tests/test_generate_blog.py
@@ -211,7 +211,7 @@ class TestBuildCardHTML:
             pub_date="2026-03-10", slug="slug"
         )
         
-        assert 'Read more &rarr;' in card
+        assert 'Read more →' in card
         assert 'href="/blog/slug"' in card
 
 


### PR DESCRIPTION
Replace HTML character entities for arrows with their corresponding symbols in blog post links to improve readability and adhere to formatting guidelines.