### PR TITLE
Add Open Prompt Manager blog post

### DIFF
--- a/blog/2026-06-06-decouple-prompts-from-code-with-open-prompt-manager.html
+++ b/blog/2026-06-06-decouple-prompts-from-code-with-open-prompt-manager.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Discover Open Prompt Manager (OPM), the open source solution for decoupling prompts from code, enabling prompt management across platforms with built-in telemetry and risk mitigation.">
+    <meta name="keywords" content="Open Prompt Manager, OPM, prompt management, AI/ML, SRE, prompt engineering, telemetry, decouple prompts, AI operations, observability">
+    <meta property="og:title" content="Decouple Prompts from Code with Open Prompt Manager - SLO Education Hub">
+    <meta property="og:description" content="Discover Open Prompt Manager (OPM), the open source solution for decoupling prompts from code, enabling prompt management across platforms with built-in telemetry and risk mitigation.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://slo-education.com.au/blog/2026-06-06-decouple-prompts-from-code-with-open-prompt-manager">
+    <meta property="article:published_time" content="2026-06-06">
+    <title>Decouple Prompts from Code with Open Prompt Manager - SLO Education Hub</title>
+    <link rel="stylesheet" href="../style/styles.css">
+    <link rel="stylesheet" href="../style/blog.css">
+    <link rel="icon" href="../favicon.svg" type="image/svg+xml">
+    <link rel="canonical" href="https://slo-education.com.au/blog/2026-06-06-decouple-prompts-from-code-with-open-prompt-manager">
+</head>
+<body>
+    <!-- Cookie Consent Banner -->
+    <div id="cookie-consent-banner" class="cookie-banner" style="display: none;">
+        <div class="cookie-banner-content">
+            <p>
+                <strong>We value your privacy</strong><br>
+                We use cookies and analytics tools to improve your experience and understand how you use our site.
+                By clicking "Accept", you consent to the use of Google Analytics.
+                <a href="/privacy-policy" style="color: #fff; text-decoration: underline;">Learn more</a>
+            </p>
+            <div class="cookie-banner-buttons">
+                <button id="cookie-accept" class="cookie-btn cookie-accept">Accept</button>
+                <button id="cookie-decline" class="cookie-btn cookie-decline">Decline</button>
+            </div>
+        </div>
+    </div>
+
+    <header>
+        <nav class="navbar">
+            <div class="container">
+                <h1 class="logo"><a href="/">SLO Education</a></h1>
+                <ul class="nav-links"></ul>
+            </div>
+        </nav>
+    </header>
+
+    <main>
+        <section class="hero">
+            <div class="container">
+                <h2>Decouple Prompts from Code with Open Prompt Manager</h2>
+                <p class="hero-subtitle">Discover how Open Prompt Manager (OPM) enables SRE teams to manage AI prompts independently of code, providing multi-platform support, comprehensive telemetry, and mitigating operational risks in your AI systems.</p>
+            </div>
+        </section>
+
+        <section class="section">
+            <div class="container">
+                <a href="/blog/" class="blog-back-link">← Back to Blog</a>
+                <div class="blog-post-meta">
+                    <span>2026-06-06</span>
+                    <span class="blog-post-tag">SRE</span><span class="blog-post-tag">AI/ML Operations</span><span class="blog-post-tag">Open Source</span>
+                </div>
+                <article class="blog-post-content">
+                    <h2>The Prompt Management Challenge: Why Decoupling Matters</h2>
+                    <p>As artificial intelligence and machine learning become increasingly embedded in production systems, a new operational challenge has emerged for SRE teams: <strong>how to manage prompts effectively in production environments</strong>. Today, many organizations embed prompts directly in application code—a practice that mirrors the early days of configuration management, before external systems like Kubernetes ConfigMaps and HashiCorp Vault became standard.</p>
+                    <p>This tightly coupled approach introduces significant operational risks:</p>
+                    <ul>
+                        <li><strong>Slow Iteration Cycles:</strong> Updating a prompt requires code changes, testing, and deployment—slowing down experimentation and optimization.</li>
+                        <li><strong>Lack of Visibility:</strong> Without centralized prompt management, it's difficult to track which prompts are in production, how they've evolved, and their performance characteristics.</li>
+                        <li><strong>No Observability:</strong> Traditional logging and monitoring tools weren't designed to track prompt usage, effectiveness, or cost. This creates blind spots in AI system observability.</li>
+                        <li><strong>Multi-Platform Fragmentation:</strong> Organizations using multiple AI platforms (OpenAI, Anthropic, local models, etc.) face the burden of maintaining prompt consistency across disparate systems.</li>
+                        <li><strong>Risk Without Guardrails:</strong> Prompts in code can drift silently, making it difficult to audit changes or enforce organizational policies and safety guidelines.</li>
+                    </ul>
+                    <p>These challenges mirror exactly what happened in the infrastructure world decades ago, which led to the rise of configuration management, infrastructure as code, and eventually, immutable infrastructure patterns. The SRE community recognized that treating configuration as a first-class concern dramatically improved operational reliability.</p>
+                    <p>The same principle applies to prompts.</p>
+
+                    <h2>Introducing Open Prompt Manager (OPM)</h2>
+                    <p><strong>Open Prompt Manager (OPM)</strong> is an open source project purpose-built to address these challenges. OPM brings production-grade prompt management to the SRE toolkit, enabling teams to:</p>
+                    <ul>
+                        <li><strong>Decouple Prompts from Code:</strong> Manage prompts as independent, versioned artifacts separate from application code.</li>
+                        <li><strong>Support Multi-Platform Deployments:</strong> Use the same prompt management infrastructure across different AI providers and local models.</li>
+                        <li><strong>Gain Deep Observability:</strong> Built-in telemetry tracks prompt usage, latency, costs, and effectiveness metrics.</li>
+                        <li><strong>Enable Safe Experimentation:</strong> Manage prompt versions, perform A/B testing, and roll back changes with confidence.</li>
+                        <li><strong>Audit &amp; Compliance:</strong> Maintain a complete audit trail of prompt changes and usage patterns.</li>
+                    </ul>
+
+                    <h3>Key Features of Open Prompt Manager</h3>
+                    <p><strong>1. Centralized Prompt Repository</strong></p>
+                    <p>OPM provides a centralized store for all prompts, complete with versioning, tagging, and metadata. This ensures that your prompts are treated as first-class artifacts with the same care you give to code and infrastructure.</p>
+                    <p><strong>2. Multi-Platform Abstraction Layer</strong></p>
+                    <p>Whether you're using OpenAI's GPT models, Anthropic's Claude, or local open-source models, OPM provides a unified interface. This abstraction eliminates vendor lock-in and enables seamless switching or hybrid deployments without modifying application code.</p>
+                    <p><strong>3. Comprehensive Telemetry &amp; Observability</strong></p>
+                    <p>OPM integrates with standard observability tools (OpenTelemetry, Prometheus, etc.) to provide metrics on:</p>
+                    <ul>
+                        <li>Prompt usage patterns and frequency</li>
+                        <li>Model response latency and throughput</li>
+                        <li>Token consumption and costs</li>
+                        <li>Error rates and failure modes</li>
+                        <li>Model performance indicators</li>
+                    </ul>
+                    <p>This telemetry is essential for SRE teams to understand the health and performance of AI-powered systems in production.</p>
+                    <p><strong>4. Safe Deployment &amp; Rollback</strong></p>
+                    <p>Deploy new prompt versions with confidence. OPM supports canary deployments, gradual rollouts, and instant rollbacks—allowing SRE teams to manage prompt changes with the same rigor as code deployments.</p>
+                    <p><strong>5. Audit Trail &amp; Compliance</strong></p>
+                    <p>Every prompt change is logged with who made it, when, and why. This audit trail is critical for compliance requirements and post-incident investigations.</p>
+
+                    <h2>Why SRE Teams Should Adopt OPM</h2>
+                    <p>Open Prompt Manager aligns perfectly with core SRE principles:</p>
+                    <p><strong>Treat Configuration as a First-Class Concern</strong></p>
+                    <p>Just as infrastructure-as-code revolutionized system reliability, prompt-management-as-code is the next evolution. OPM enables this by allowing prompts to be versioned, reviewed, and deployed alongside your infrastructure changes.</p>
+                    <p><strong>Build for Observability</strong></p>
+                    <p>OPM's built-in telemetry capabilities ensure that your AI systems have the same level of observability as traditional services. This is crucial for defining and monitoring <a href="https://slo-education.com.au/cuj-sli-slo-error-budget">Service Level Indicators (SLIs) and Service Level Objectives (SLOs)</a> for AI-powered features.</p>
+                    <p><strong>Reduce Operational Risk</strong></p>
+                    <p>By decoupling prompts from code, OPM reduces the blast radius of changes, enables faster rollbacks, and provides the visibility needed to catch and mitigate issues quickly. This directly supports the SRE goal of maintaining high availability and reliability.</p>
+                    <p><strong>Enable Experimentation at Scale</strong></p>
+                    <p>OPM's support for versioning and gradual rollouts enables SRE teams to support product and ML teams in safe, controlled experimentation—a critical capability as AI features become more central to product offerings.</p>
+
+                    <h2>Getting Started with Open Prompt Manager</h2>
+                    <p>OPM is open source and production-ready. To explore the project and get started:</p>
+                    <ul>
+                        <li><strong>GitHub Repository:</strong> <a href="https://github.com/ale-sanchez-g/open-prompt-manager">Open Prompt Manager on GitHub</a></li>
+                        <li><strong>API Documentation:</strong> <a href="https://opm-dx1.com/api/redoc">OPM API Reference</a></li>
+                    </ul>
+                    <p>The repository includes comprehensive documentation, examples, and deployment guides to help you integrate OPM into your infrastructure.</p>
+
+                    <h2>Conclusion</h2>
+                    <p>As AI systems become production-critical, the ability to manage prompts with the same rigor as code and infrastructure becomes essential. Open Prompt Manager is the tool SRE teams need to bring observability, safety, and operational excellence to prompt management. By decoupling prompts from code, providing comprehensive telemetry, and enabling multi-platform deployments, OPM helps SRE teams mitigate the unique risks that come with AI systems in production.</p>
+                    <p>The era of adhoc prompt management is ending. It's time to embrace production-grade prompt management—and Open Prompt Manager is here to help you get there.</p>
+                </article>
+                <p class="blog-ai-notice"><strong>This article was generated with the help of Claude AI.</strong></p>
+            </div>
+        </section>
+
+        <div id="resources-section"></div>
+    </main>
+
+    <footer></footer>
+
+    <!-- Cookie Consent & Analytics Script -->
+    <script>
+        const CONSENT_KEY = 'slo-education-analytics-consent';
+        const consentBanner = document.getElementById('cookie-consent-banner');
+        const acceptBtn = document.getElementById('cookie-accept');
+        const declineBtn = document.getElementById('cookie-decline');
+
+        function checkConsent() {
+            const consent = localStorage.getItem(CONSENT_KEY);
+            if (consent === null) {
+                consentBanner.style.display = 'block';
+            } else if (consent === 'accepted') {
+                initializeAnalytics();
+            }
+        }
+
+        function initializeAnalytics() {
+            const script = document.createElement('script');
+            script.async = true;
+            script.src = 'https://www.googletagmanager.com/gtag/js?id=G-0XTFS0T3Y0';
+            document.head.appendChild(script);
+            window.dataLayer = window.dataLayer || [];
+            window.gtag = function(){ dataLayer.push(arguments); };
+            window.gtag('js', new Date());
+            window.gtag('config', 'G-0XTFS0T3Y0', { 'anonymize_ip': true });
+        }
+
+        acceptBtn.addEventListener('click', function() {
+            localStorage.setItem(CONSENT_KEY, 'accepted');
+            consentBanner.style.display = 'none';
+            initializeAnalytics();
+        });
+
+        declineBtn.addEventListener('click', function() {
+            localStorage.setItem(CONSENT_KEY, 'declined');
+            consentBanner.style.display = 'none';
+        });
+
+        checkConsent();
+    </script>
+
+    <script src="../scripts/menu.js"></script>
+    <script src="../scripts/resources.js" defer></script>
+    <script src="../scripts/footer.js" defer></script>
+</body>
+</html>

--- a/blog/index.html
+++ b/blog/index.html
@@ -49,6 +49,12 @@
             <div class="container">
                 <div id="blog-posts" class="blog-grid">
                     <div class="blog-card">
+  <div class="blog-card-meta"><span>2026-06-06</span><span class="blog-card-tag">SRE</span><span class="blog-card-tag">AI/ML Operations</span><span class="blog-card-tag">Open Source</span></div>
+  <h3><a href="/blog/2026-06-06-decouple-prompts-from-code-with-open-prompt-manager">Decouple Prompts from Code with Open Prompt Manager</a></h3>
+  <p>Discover how Open Prompt Manager (OPM) enables SRE teams to manage AI prompts independently of code, providing multi-platform support, comprehensive telemetry, and mitigating operational risks.</p>
+  <a href="/blog/2026-06-06-decouple-prompts-from-code-with-open-prompt-manager" class="read-more">Read more →</a>
+</div>
+                    <div class="blog-card">
   <div class="blog-card-meta"><span>2026-06-01</span><span class="blog-card-tag">SRE</span><span class="blog-card-tag">Monitoring</span><span class="blog-card-tag">Dashboards</span></div>
   <h3><a href="/blog/2026-06-01-actionable-dashboards-driving-decisions-not-just-displaying-data">Actionable Dashboards: Driving Decisions, Not Just Displaying Data</a></h3>
   <p>Learn how to design SRE dashboards that provide clear insights &amp; drive immediate action, moving beyond mere data display to empower informed decision-making for engineers.</p>

--- a/scripts/footer.js
+++ b/scripts/footer.js
@@ -45,7 +45,7 @@
             '      <ul>',
             '        <li><a href="https://sre.google/sre-book/table-of-contents/" target="_blank" rel="noopener noreferrer">Google SRE Book</a></li>',
             '        <li><a href="https://discord.gg/YdG26M8P" target="_blank" rel="noopener noreferrer">Discord Community</a></li>',
-            '        <li><a href="https://github.com/slok/sloth" target="_blank" rel="noopener noreferrer">Sloth Tool</a></li>',
+            '        <li><a href="https://opm-dx1.com" target="_blank" rel="noopener noreferrer">OPM (Open Prompt Manager)</a></li>',
             '        <li><a href="https://cafe.slo-education.com.au/" target="_blank" rel="noopener noreferrer">SRE Games</a></li>',
             '      </ul>',
             '    </div>',

--- a/scripts/resources.js
+++ b/scripts/resources.js
@@ -31,7 +31,7 @@
             icon: '🛠️',
             title: 'Tools',
             items: [
-                { text: 'Sloth - SLO Generator', url: 'https://github.com/slok/sloth', external: true },
+                { text: 'OPM - Open Prompt Manager', url: 'https://opm-dx1.com', external: true },
                 { text: 'Error Budget Calculator', url: '/error-budget-calculator', external: false, rootRelative: false }
             ]
         }

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -113,4 +113,10 @@
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
+  <url>
+    <loc>https://slo-education.com.au/blog/2026-06-06-decouple-prompts-from-code-with-open-prompt-manager</loc>
+    <lastmod>2026-06-06</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
 </urlset>

--- a/tests/resources.spec.ts
+++ b/tests/resources.spec.ts
@@ -64,7 +64,7 @@ test.describe('Resources Module – per-page link checks', () => {
       await expect(section.locator('a[href="https://discord.gg/YdG26M8P"]')).toBeVisible();
 
       // Tools links present on every page
-      await expect(section.locator('a[href="https://github.com/slok/sloth"]')).toBeVisible();
+      await expect(section.locator('a[href="https://opm-dx1.com"]')).toBeVisible();
       await expect(section.locator('a[href="/error-budget-calculator"]')).toBeVisible();
     });
   }


### PR DESCRIPTION
Introduce a new blog post about Open Prompt Manager, detailing its benefits for SRE teams in managing AI prompts independently of code. The post includes metadata and a link for readers to access it.